### PR TITLE
New task ID for failed tasks

### DIFF
--- a/src/main/scala/eu/inn/samza/mesos/mapping/TaskOfferMapper.scala
+++ b/src/main/scala/eu/inn/samza/mesos/mapping/TaskOfferMapper.scala
@@ -41,7 +41,7 @@ class TaskOfferMapper(strategy: ResourceMappingStrategy) {
 
   private val constraints = new ResourceConstraints
 
-  // not sure if this is a good idea
+  // not sure if this is a good idea <======= TODO why are these even here?
   addCpuConstraint(1.0)
   addMemConstraint(1024.0)
 


### PR DESCRIPTION
Previously, when the Samza container Mesos task would fail, the Samza scheduler would run the exact same Mesos task again, with the same taskId. This replacement task would be killed by its executor immediately, and then the Samza scheduler would re-run this task again a 2nd time. This 2nd re-run would actually succeed and keep running.

I think by keeping the same taskId, the 1st replacement task would get assigned to the same executor, which was just in the process of cleaning up after the original task failed. This executor would then kill the 1st replacement task. Then I think the 2nd replacement task would be a fresh new executor and it would all work properly.

This PR essentially just gives a failed task a new taskId, and this seems to work better - the 1st replacement task runs properly. This is also essentially what Marathon does - failed tasks get new taskIds when they are re-run.
