### PR TITLE
Shutdown

### DIFF
--- a/src/main/scala/eu/inn/samza/mesos/SamzaScheduler.scala
+++ b/src/main/scala/eu/inn/samza/mesos/SamzaScheduler.scala
@@ -33,8 +33,8 @@ class SamzaScheduler(config: Config, state: SamzaSchedulerState, offerMapper: Ta
 
   info("Samza scheduler created.")
 
-  override def registered(driver: SchedulerDriver, framework: FrameworkID, master: MasterInfo) {
-    info("Samza framework registered")
+  override def registered(driver: SchedulerDriver, frameworkId: FrameworkID, master: MasterInfo) {
+    info(s"Samza framework registered with ID ${frameworkId.getValue}")
   }
 
   override def reregistered(driver: SchedulerDriver, master: MasterInfo): Unit = {


### PR DESCRIPTION
Stops the Samza job framework (and all of its Samza container tasks) on SIGTERM. Mesos will issue a `docker stop` to stop a task, which sends SIGTERM to the java process.